### PR TITLE
Hack to get the webpack build not to hang

### DIFF
--- a/build/tasks/build.coffee
+++ b/build/tasks/build.coffee
@@ -28,6 +28,13 @@ colors = ['cyan', 'magenta', 'blue', 'yellow']
 module.exports = (gulp, config) ->
   runSequence = require('run-sequence').use gulp
 
+  # this is really nasty, but webpack process is hanging so the only way to get
+  # the CI server build working is to kill the process manually
+  kill = (cb) ->
+    ->
+       cb?()
+       process.exit 0
+
   # Get local node module binary path
   bin = (binary) ->
     binPath = "node_modules/.bin/#{binary}"
@@ -87,6 +94,8 @@ module.exports = (gulp, config) ->
 
     spawned.stdout.on 'data', (data) ->
       process.stdout.write prefixOutput data, color
+      if /.*\+.*hidden\smodules/.test data
+        cb()
 
     spawned.stderr.on 'data', (data) ->
       process.stderr.write prefixOutput data, 'red'
@@ -130,7 +139,8 @@ module.exports = (gulp, config) ->
       'schemas'
       'config'
       ['webpack', 'copy:assets']
-      cb
+      kill cb
+      # cb
     )
 
   gulp.task 'copy:assets', ->

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -210,9 +210,9 @@ var config = {
     new webpack.optimize.DedupePlugin()
   ].concat(DEV ? [
     // Dev plugins
-    new WebpackNotifierPlugin()
-    , new webpack.HotModuleReplacementPlugin()
-    , new webpack.NoErrorsPlugin()
+    new WebpackNotifierPlugin(),
+    new webpack.HotModuleReplacementPlugin(),
+    new webpack.NoErrorsPlugin()
   ] : [
     // Release plugins
     new webpack.ExtendedAPIPlugin(),


### PR DESCRIPTION
This is really nasty, but there are so many reason webpack could be hanging. Sometimes it hangs on node-sass, sometimes uglify. I tried commenting out almost the entire file and it still hung. I tried the UV_THREADPOOL_SIZE fix, and that didn't do anything.

It would be great to eventually figure out a better fix, but I have no idea what webpack is doing :smile: 